### PR TITLE
Fix for issue #159 Scala Find Usages results are in random order with…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <scala.console.version>1.8.1.0</scala.console.version>
         <scala.core.version>1.8.1.0</scala.core.version>
         <scala.debugger.version>1.8.1.0</scala.debugger.version>
-        <scala.debugger.projects.version>1.8.1.0</scala.debugger.projects.version>
+        <scala.debugger.projects.version>1.8.1.1</scala.debugger.projects.version>
         <scala.editor.version>1.8.1.1</scala.editor.version>
         <scala.fontscolors.version>1.8.1.1</scala.fontscolors.version>
         <scala.maven.version>1.8.1.0</scala.maven.version>
@@ -148,6 +148,7 @@
 
                 <plugin>
                     <!-- https://github.com/mojohaus/nb-repository-plugin/ -->
+                    <!-- mvn nb-repository:populate -->
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>nb-repository-plugin</artifactId>
                     <version>1.3</version>

--- a/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
+++ b/scala.refactoring/src/main/scala/org/netbeans/modules/scala/refactoring/WhereUsedElement.scala
@@ -164,10 +164,13 @@ object WhereUsedElement {
 }
 
 class WhereUsedElement(bounds: PositionBounds, displayText: String, parentFile: FileObject,
-                       name: String, range: OffsetRange, icon: Icon) extends SimpleRefactoringElementImplementation {
+                       name: String, range: OffsetRange, icon: Icon) extends SimpleRefactoringElementImplementation
+      with scala.math.Ordered[WhereUsedElement] {
 
   ElementGripFactory.getDefault.put(parentFile, name, range, icon)
 
+  def compare(that: WhereUsedElement) = (this.getPosition().getBegin().getLine() - that.getPosition().getBegin().getLine())
+  
   def getLookup: Lookup = {
     val composite = ElementGripFactory.getDefault.get(parentFile, bounds.getBegin.getOffset) match {
       case null => parentFile


### PR DESCRIPTION
…in file

WhereUsedElement now extends Ordered, comparing line numbers
WhereUsedQueryPlugin sorts foundElements before adding to results
(language refactoring plugins must now implement results sorting. See: https://hg.netbeans.org/main-golden/annotate/bebcb8289952/refactoring.api/src/org/netbeans/modules/refactoring/spi/impl/RefactoringPanel.java#l466 )
